### PR TITLE
Added logic to skip n_rating if not found in page instead of exiting program

### DIFF
--- a/enhance_goodreads_export/enhance_export.py
+++ b/enhance_goodreads_export/enhance_export.py
@@ -6,6 +6,7 @@ import urllib.parse
 
 import backoff
 import dateutil.parser
+import numpy as np
 import requests
 from bs4 import BeautifulSoup
 from bs4 import Tag
@@ -157,8 +158,10 @@ def update_book_data(book: dict[str, str], session: requests.Session) -> None:
     )
     if n_ratings_match is None:
         print(book_page)
-        raise ValueError("Did not find number of ratings in book page!")
-    book["n_ratings"] = n_ratings_match.group(1)
+        print("Did not find number of ratings in book page, not adding number of ratings!")
+        book["n_ratings"] = np.nan
+    else:
+        book['n_ratings'] = n_ratings_match.group(1)
 
     shelves_url_match = re.search(
         '(?:"|&quot;)[^"&]*(work/shelves[^"&]+)(?:"|&quot;)', book_page


### PR DESCRIPTION
One book in my library was causing a program crash cause number of ratings was not found in page -- I was going to suppress the page print but perhaps you want to keep it for inspection. 
