### PR TITLE
Fix crash when `--genre_votes` is not specified

### DIFF
--- a/enhance_goodreads_export/__main__.py
+++ b/enhance_goodreads_export/__main__.py
@@ -45,6 +45,7 @@ def main():
 
     argument_parser.add_argument(
         "--genre_votes",
+        default=argparse.SUPPRESS,
         help=(
             "min number of votes needed to add a genre, either integer or percentage of"
             ' highest voted genre in the book (e.g. "11" or "10%%")'


### PR DESCRIPTION
`enhance_export` expects the given `options` `dict` to not have a
`genre_votes` key at all. However, the way `argparse` works, if you
don't specify a command line parameter for `--genre_votes`, the value
is still present, it's just `None`. Adding `default=argparse.SUPPRESS`
changes this behavior to truly remove the value.

An alternative, and possibly less arcane fix would be to change
`enhance_export` to handle the scenario where `options["genre_votes"]`
is `None`. Let me know if you prefer that.

Before
======

    $ python -m enhance_goodreads_export -c my_export_file.csv
    Traceback (most recent call last):
      File "<frozen runpy>", line 198, in _run_module_as_main
      File "<frozen runpy>", line 88, in _run_code
      File "/home/jeremy/src/github.com/PaulKlinger/Enhance-GoodReads-Export/enhance_goodreads_export/__main__.py", line 78, in <module>
        main()
      File "/home/jeremy/src/github.com/PaulKlinger/Enhance-GoodReads-Export/enhance_goodreads_export/__main__.py", line 72, in main
        enhance_export(options)
      File "/home/jeremy/src/github.com/PaulKlinger/Enhance-GoodReads-Export/enhance_goodreads_export/enhance_export.py", line 208, in enhance_export
        options["genre_votes"].strip().removesuffix("%").strip()
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    AttributeError: 'NoneType' object has no attribute 'strip'

After
=====

    $ python -m enhance_goodreads_export -c my_export_file.csv
    Error reading export file: [Errno 2] No such file or directory: 'my_export_file.csv'
